### PR TITLE
Add tests, more utility functions for ux-renderer

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,10 +1,12 @@
 /*.tgz
+*.map
 /node_modules/
 /.nyc_output/
 /src/
 /coverage/
 /src/
 /test/
+/.prettier*
 /.mocharc.json
 /tsconfig.json
 /tslint.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jsiterable",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jsiterable",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "No-dependency javascript iterable library exposing functional operations over iterables",
     "main": "./lib/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "url": "https://github.com/riteshrao/jsiterable/issues"
     },
     "homepage": "https://github.com/riteshrao/jsiterable#readme",
+    "sideEffects": false,
     "devDependencies": {
         "@types/chai": "^4.1.7",
         "@types/mocha": "^5.2.6",

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,9 +18,9 @@ export class Iterable<T> implements LibIterable<T> {
      */
     constructor(source: LibIterable<T> | (() => LibIterable<T>)) {
         if (typeof source === 'function') {
-            // source is an function that returns an Iterable. Get its iterator:
-            this._source = { 
-                [Symbol.iterator]: () => source()[Symbol.iterator]() 
+            // source is an function that returns an Iterable. Get its iterator lazily:
+            this._source = {
+                [Symbol.iterator]: () => source()[Symbol.iterator]()
             };
         } else if (source && typeof source[Symbol.iterator] === 'function') {
             // source is a es6 iterable, use as-is:
@@ -46,7 +46,7 @@ export class Iterable<T> implements LibIterable<T> {
             return this._source.length;
         } else {
             let num = 0;
-            for (let _ of this._source) ++num;
+            for (let _ of this._source) { ++num; }
             return num;
         }
     }
@@ -147,7 +147,7 @@ export class Iterable<T> implements LibIterable<T> {
 
         return false;
     }
-    
+
     /**
      * @description Determines whether all elements in the source satisfy the specified test.
      * @param {(item: T, index: number) => boolean} test The test function.
@@ -164,7 +164,7 @@ export class Iterable<T> implements LibIterable<T> {
 
         return true;
     }
-    
+
     /**
      * @description Gets an empty iterable.
      * @static

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,15 +42,9 @@ export class Iterable<T> implements LibIterable<T> {
      * @memberof Iterable
      */
     count(): number {
-        if (Array.isArray(this._source)) {
-            return this._source.length;
-        } else if (this._source instanceof Set || this._source instanceof Map) {
-            return this._source.size;
-        } else {
-            let num = 0;
-            for (const _ of this._source) { ++num; }
-            return num;
-        }
+        let num = 0;
+        for (const _ of this._source) { ++num; }
+        return num;
     }
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,9 +44,11 @@ export class Iterable<T> implements LibIterable<T> {
     count(): number {
         if (Array.isArray(this._source)) {
             return this._source.length;
+        } else if (this._source instanceof Set || this._source instanceof Map) {
+            return this._source.size;
         } else {
             let num = 0;
-            for (let _ of this._source) { ++num; }
+            for (const _ of this._source) { ++num; }
             return num;
         }
     }

--- a/test/iterable.test.ts
+++ b/test/iterable.test.ts
@@ -11,13 +11,18 @@ describe('Iterable', () => {
         expect(() => new Iterable(null)).to.throw(ReferenceError);
         expect(() => new Iterable(undefined)).to.throw(ReferenceError);
     });
-    
+
     it('.ctor shoud support generators', () => {
         const iterable = new Iterable(function* foo() {
             yield 1;
             yield 2;
         });
 
+        expect(iterable.count()).to.equal(2);
+    });
+
+    it('.ctor shoud support lazy functions', () => {
+        const iterable = new Iterable(() => [1, 2]);
         expect(iterable.count()).to.equal(2);
     });
 
@@ -353,10 +358,10 @@ describe('Iterable', () => {
             expect(items.length).to.equal(9);
             expect(items.filter(x => x === 'charlie').length).to.equal(1);
         });
-        
+
         it('.distinct should be invocable multiple times', () => {
             const items = iterable.distinct(x => x);
-            
+
             // assert items can be iterated on multiple times
             expect(items.count()).to.equal(9);
             expect(items.count()).to.equal(9);
@@ -397,12 +402,12 @@ describe('Iterable', () => {
 
         it('.filter should be invocable multiple times', () => {
             const filtered = iterable.filter(x => x.startsWith('b'));
-            
+
             // assert filtered can be iterated on multiple times
             expect(filtered.first()).to.equal('bravo');
             expect(filtered.first()).to.equal('bravo');
         });
-        
+
         it('.map should map all items', () => {
             const items = iterable.map(x => x.length).items();
             expect(items.length).to.equal(10);
@@ -410,10 +415,10 @@ describe('Iterable', () => {
             expect(items[5]).to.equal(7);
             expect(items[9]).to.equal(7);
         });
-        
+
         it('.map should be invocable multiple times', () => {
             const items = iterable.map(x => x + '_map');
-            
+
             // assert items can be iterated on multiple times
             expect(items.first()).to.equal('alpha_map');
             expect(items.first()).to.equal('alpha_map');

--- a/test/iterable.test.ts
+++ b/test/iterable.test.ts
@@ -13,7 +13,7 @@ describe('Iterable', () => {
     });
     
     it('.ctor shoud support generators', () => {
-        const iterable = new Iterable(function* () {
+        const iterable = new Iterable(function* foo() {
             yield 1;
             yield 2;
         });
@@ -100,15 +100,6 @@ describe('Iterable', () => {
             expect(items[9]).to.equal('charlie9');
         });
 
-        it('.forEach should iterate over all items', () => {
-            const items: string[] = [];
-            iterable.forEach((x, i) => items.push(x + i.toString()));
-            expect(items.length).to.equal(10);
-            expect(items[0]).to.equal('alpha0');
-            expect(items[5]).to.equal('foxtrot5');
-            expect(items[9]).to.equal('charlie9');
-        });
-
         it('.mapMany should map all items', () => {
             const items = iterable
                 .map(x => x.split(''))
@@ -133,34 +124,6 @@ describe('Iterable', () => {
 
         it('.every should return false when any element does not match condition', () => {
             expect(iterable.every(x => x === 'alpha')).to.be.false;
-        });
-
-        it('.sort should sort numbers automatically', () => {
-            const items = new Iterable([1, 3, 2]);
-            expect(items.sort().items(), 'sorted array').to.eql([1, 2, 3]);
-            
-            // assert we didn't mutate the original array:
-            expect(items.items(), 'original array').to.eql([1, 3, 2]);
-        });
-        
-        it('.sort should sort strings automatically', () => {
-            const items = new Iterable(['a', 'c', 'b']);
-            expect(items.sort().items(), 'sorted array').to.eql(['a', 'b', 'c']);
-        });
-
-        it('.sort should sort objects', () => {
-            const items = new Iterable([
-                { str: 'a' }, 
-                { str: 'c' }, 
-                { str: 'b' }, 
-            ]);
-            
-            const result = items
-                .sort((a, b) => a.str.localeCompare(b.str))
-                .map(x => x.str)
-                .items();
-            
-            expect(result).to.eql(['a', 'b', 'c']);
         });
     });
 


### PR DESCRIPTION
There's a bunch of places in ux-renderer that would benefit from using Iterables instead of array.map/.filter etc. This PR makes some changes that makes it easier to consume Iterable:

1. The constructor now supports taking in both an es6 iterable _or_ a function that returns an es6 iterable. We can now do:
    a. `new Iterable([1, 2])`
    b. `new Iterable(function* () { yield 1; })`
    b. `new Iterable(() => map.keys())`

    This also reduces the duplicate code in the private functions to create a new es6 Iterable.

2. Adds a second, optional, `index` argument to callback functions to match the Array functions. This is used in a bunch of places in ux-renderer to, for example, add special styling for first-child, generate React keys etc.

3. Fix `.first()` to allow falsy values

4. Add `.every()` with Array.every() semantics (the inverse of `.some`)

5. Add tests to get back to 100% coverage

5. Remove unnecessary files from npm package, and add `sideEffects: true` so webpack can prune unused code.