### PR TITLE
Add concat, object keys, and object values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jsiterable",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jsiterable",
-    "version": "3.0.2",
+    "version": "3.0.3",
     "description": "No-dependency javascript iterable library exposing functional operations over iterables",
     "main": "./lib/index.js",
     "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -216,32 +216,32 @@ export class Iterable<T> implements LibIterable<T> {
     static empty<T>(): Iterable<T> {
         return new Iterable<T>([]);
     }
-}
 
-/**
- * Returns an Iterable of the specified object's keys.
- * @param obj {any} An object
- * @returns {Iterable<string>} The keys of the specified object.
- */
-export function objectKeys(obj: any): Iterable<string> {
-    return new Iterable(function* () {
-        for (const key in obj) {
-            yield key;
-        }
-    });
-}
+    /**
+     * Returns an Iterable of the specified object's keys.
+     * @param obj {any} An object
+     * @returns {Iterable<string>} The keys of the specified object.
+     */
+    static keys(obj: any): Iterable<string> {
+        return new Iterable(function* () {
+            for (const key in obj) {
+                yield key;
+            }
+        });
+    }
 
-/**
- * Returns an Iterable of the specified object's values.
- * @param obj {any} An object
- * @returns {Iterable<any>} The values of the specified object.
- */
-export function objectValues(obj: any): Iterable<any> {
-    return new Iterable(function* () {
-        for (const key in obj) {
-            yield obj[key];
-        }
-    });
+    /**
+     * Returns an Iterable of the specified object's values.
+     * @param obj {any} An object
+     * @returns {Iterable<any>} The values of the specified object.
+     */
+    static values(obj: any): Iterable<any> {
+        return new Iterable(function* () {
+            for (const key in obj) {
+                yield obj[key];
+            }
+        });
+    }
 }
 
 export default Iterable;

--- a/test/iterable.test.ts
+++ b/test/iterable.test.ts
@@ -1,6 +1,6 @@
 import 'mocha';
 import { expect } from 'chai';
-import Iterable, { objectKeys, objectValues } from '../src';
+import Iterable from '../src';
 
 describe('Iterable', () => {
     it('.ctor should throw when source is not iterable', () => {
@@ -463,46 +463,46 @@ describe('Iterable', () => {
         });
     });
 
-    describe('objectKeys', () => {
+    describe('object keys', () => {
         it('expect empty object to have 0 keys', () => {
-            const keys = objectKeys({});
+            const keys = Iterable.keys({});
             expect(keys.count()).to.equal(0);
         });
 
         it('expect null object to have 0 keys', () => {
-            const keys = objectKeys(null);
+            const keys = Iterable.keys(null);
             expect(keys.count()).to.equal(0);
         });
 
         it('expect undefined object to have 0 keys', () => {
-            const keys = objectKeys(undefined);
+            const keys = Iterable.keys(undefined);
             expect(keys.count()).to.equal(0);
         });
 
         it('expect non-empty object to have keys', () => {
-            const keys = objectKeys({ a: 1, b: 2 });
+            const keys = Iterable.keys({ a: 1, b: 2 });
             expect(keys.items()).to.eql(['a', 'b']);
         });
     });
 
-    describe('objectValues', () => {
+    describe('object values', () => {
         it('expect empty object to have 0 values', () => {
-            const keys = objectValues({});
+            const keys = Iterable.values({});
             expect(keys.count()).to.equal(0);
         });
 
         it('expect null object to have 0 values', () => {
-            const keys = objectValues(null);
+            const keys = Iterable.values(null);
             expect(keys.count()).to.equal(0);
         });
 
         it('expect undefined object to have 0 values', () => {
-            const keys = objectValues(undefined);
+            const keys = Iterable.values(undefined);
             expect(keys.count()).to.equal(0);
         });
 
         it('expect non-empty object to have values', () => {
-            const keys = objectValues({ a: 1, b: 2 });
+            const keys = Iterable.values({ a: 1, b: 2 });
             expect(keys.items()).to.eql([1, 2]);
         });
     });

--- a/test/iterable.test.ts
+++ b/test/iterable.test.ts
@@ -1,6 +1,6 @@
 import 'mocha';
 import { expect } from 'chai';
-import Iterable from '../src';
+import Iterable, { objectKeys, objectValues } from '../src';
 
 describe('Iterable', () => {
     it('.ctor should throw when source is not iterable', () => {
@@ -440,6 +440,70 @@ describe('Iterable', () => {
 
         it('.some should return false when entity exists', () => {
             expect(iterable.some(x => x.includes('z'))).to.be.false;
+        });
+    });
+
+    describe('concat', () => {
+        it('can concatenate with arrays', () => {
+            const src = new Iterable(['a', 'b']);
+            const result = src.concat(['c', 'd']);
+            expect(result.items()).to.eql(['a', 'b', 'c', 'd']);
+        });
+
+        it('can concatenate with empty iterable', () => {
+            const src = new Iterable(['a', 'b']);
+            const result = src.concat(Iterable.empty());
+            expect(result.items()).to.eql(['a', 'b']);
+        });
+
+        it('can concatenate with lazy iterable', () => {
+            const src = new Iterable(['a', 'b']);
+            const result = src.concat(new Iterable(() => ['c', 'd']));
+            expect(result.items()).to.eql(['a', 'b', 'c', 'd']);
+        });
+    });
+
+    describe('objectKeys', () => {
+        it('expect empty object to have 0 keys', () => {
+            const keys = objectKeys({});
+            expect(keys.count()).to.equal(0);
+        });
+
+        it('expect null object to have 0 keys', () => {
+            const keys = objectKeys(null);
+            expect(keys.count()).to.equal(0);
+        });
+
+        it('expect undefined object to have 0 keys', () => {
+            const keys = objectKeys(undefined);
+            expect(keys.count()).to.equal(0);
+        });
+
+        it('expect non-empty object to have keys', () => {
+            const keys = objectKeys({ a: 1, b: 2 });
+            expect(keys.items()).to.eql(['a', 'b']);
+        });
+    });
+
+    describe('objectValues', () => {
+        it('expect empty object to have 0 values', () => {
+            const keys = objectValues({});
+            expect(keys.count()).to.equal(0);
+        });
+
+        it('expect null object to have 0 values', () => {
+            const keys = objectValues(null);
+            expect(keys.count()).to.equal(0);
+        });
+
+        it('expect undefined object to have 0 values', () => {
+            const keys = objectValues(undefined);
+            expect(keys.count()).to.equal(0);
+        });
+
+        it('expect non-empty object to have values', () => {
+            const keys = objectValues({ a: 1, b: 2 });
+            expect(keys.items()).to.eql([1, 2]);
         });
     });
 });


### PR DESCRIPTION
I was going over use-cases of Iterable in ux-renderer and found many unnecessary array allocations that could be avoided if we had lazy implementations of Array.concat(), Object.keys(), and Object.values().

I also [ran perf tests](http://jsben.ch/EtVI5) on bind vs. inline functions in Iterator, and it turns out inline functions are more than _twice_ as fast as binding to private functions in Chrome/Edge beta (and ~25% faster in Firefox. Old Edge is roughly the same.) So, this PR also replaces usages of .bind with inline generators.