### PR TITLE
[perf] Move type checks on source from ctor to iterator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jsiterable",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jsiterable",
-    "version": "3.0.3",
+    "version": "3.0.4",
     "description": "No-dependency javascript iterable library exposing functional operations over iterables",
     "main": "./lib/index.js",
     "scripts": {

--- a/test/iterable.test.ts
+++ b/test/iterable.test.ts
@@ -3,13 +3,13 @@ import { expect } from 'chai';
 import Iterable from '../src';
 
 describe('Iterable', () => {
-    it('.ctor should throw when source is not iterable', () => {
-        expect(() => new Iterable(1 as any)).to.throw(ReferenceError);
+    it('.items should throw when source is not iterable', () => {
+        expect(() => new Iterable(1 as any).items()).to.throw(TypeError);
     });
 
-    it('.ctor shoud throw when source is null or undefined', () => {
-        expect(() => new Iterable(null)).to.throw(ReferenceError);
-        expect(() => new Iterable(undefined)).to.throw(ReferenceError);
+    it('.items shoud throw when source is null or undefined', () => {
+        expect(() => new Iterable(null).items()).to.throw(TypeError);
+        expect(() => new Iterable(undefined).items()).to.throw(TypeError);
     });
 
     it('.ctor shoud support generators', () => {


### PR DESCRIPTION
The Iterable constructor currently does runtime type checking to make sure `source` is of the correct shape, and creates a dummy source for lazy iterables.

Refactoring this to the `iterator` method [improves the performance of using Iterables by 10-20%](https://jsperf.com/iterable-perf), reduces the bundle size, and (IMO) provides the same developer experience:
1. In most cases, typescript will block us from passing in a non-iterable source. We're relying on typescript anyway for other scenarios (e.g., we're not checking if the input to `filter` is actually a function.)
2. The runtime error thrown by the native js engine shows pretty much the same message:
    ```
    new Iterable(null).count();
    VM9270:7 Uncaught TypeError: object null is not iterable (cannot read property Symbol(Symbol.iterator))
        at Iterable2.[Symbol.iterator] (<anonymous>:7:59)
        at Iterable2.count (<anonymous>:10:21)
        at <anonymous>:1:21
    ```